### PR TITLE
docs(readme): 역방향 조회 설명에서 없는 검색 기능 암시 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ WebFlux는 요청 하나를 처리하면서 스레드를 여러 번 갈아탑니
 
 ### 3. 코드 → API 역방향 조회
 
-`Code to Endpoint Index`는 방향을 뒤집습니다. 메서드 이름을 넣으면 **그 메서드를 실행한 API 목록**이 나옵니다. 코드를 고친 뒤 어디부터 다시 확인할지 정할 때 쓰는 기능입니다. 메서드 이름은 JVM 내부 표기 대신 `find(long): OrderResponse`처럼 읽기 쉬운 형태로 보여줍니다.
+`Code to Endpoint Index`는 방향을 뒤집은 표입니다. 메서드마다 **그 메서드를 실행한 API가 나열됩니다.** 코드를 고친 뒤 어디부터 다시 확인할지 정할 때 쓰면 됩니다. 메서드 이름은 JVM 내부 표기 대신 `find(long): OrderResponse`처럼 읽기 쉬운 형태로 보여줍니다.
+
+> 지금은 표 전체가 그려진 정적 HTML입니다. 브라우저 찾기(`Ctrl`/`Cmd`+`F`)로 찾으세요. 리포트 안에서 바로 걸러 보는 필터는 [이슈 #5](https://github.com/reqover-labs/reqover/issues/5)에 있습니다 — 기여하기 좋은 항목입니다.
 
 ![SharedValidator를 두 개의 API에 연결해 보여주는 역방향 조회](docs/assets/reqover-code-to-endpoint-index.png)
 


### PR DESCRIPTION
## 변경 내용

#11에서 제가 넣은 문장에 **사실 오류**가 있어 고칩니다. README 한 문단, 코드 변경 없습니다.

현재 main의 문장:

> `Code to Endpoint Index`는 방향을 뒤집습니다. **메서드 이름을 넣으면** 그 메서드를 실행한 API 목록이 나옵니다.

"넣으면"이 리포트에 입력창이 있는 것처럼 읽힙니다. 실제로는 없습니다 — `HtmlCoverageReportRenderer`에 `input`이나 필터 스크립트가 없고, 표 전체를 그린 정적 HTML입니다. 텍스트 필터는 아직 #5로 열려 있는 요청입니다.

원래 영문 README는 "shows the observed APIs that executed a method"로 중립적이었는데, 쉽게 풀어쓰는 과정에서 없는 상호작용을 만들어 넣었습니다.

### 수정 후

> `Code to Endpoint Index`는 방향을 뒤집은 표입니다. 메서드마다 **그 메서드를 실행한 API가 나열됩니다.** …
>
> \> 지금은 표 전체가 그려진 정적 HTML입니다. 브라우저 찾기(`Ctrl`/`Cmd`+`F`)로 찾으세요. 리포트 안에서 바로 걸러 보는 필터는 [이슈 #5](https://github.com/reqover-labs/reqover/issues/5)에 있습니다 — 기여하기 좋은 항목입니다.

없는 기능을 조용히 지우는 대신, **지금 어떻게 찾는지**(브라우저 찾기)를 알려주고 #5를 기여 기회로 연결했습니다.

### 함께 확인한 것

같은 종류의 주장 하나를 더 대조했습니다 — "2개 이상의 API가 도달한 메서드는 따로 강조됩니다"는 **정확합니다.** `HtmlCoverageReportRenderer`에 `tr.shared` 스타일과 `methods reached by 2+ endpoints` 집계가 실제로 있습니다. 수정 불필요.

## 체크리스트

- [x] README 한 문단만 변경 — 코드 변경 없음
- [x] 주장을 `reqover-report` 코드와 대조 확인
- [x] 시크릿 없음 / 의존성 변경 없음
- [ ] `./gradlew test` / `build` — 문서 전용 변경이라 로컬 미실행. CI 결과로 확인 부탁드립니다

## 참고

#11이 제 후속 커밋 2개가 붙기 전에 머지되어 이 수정이 함께 들어가지 못했습니다. 팀 역할 갱신(`1ef1a20`)은 이미 main에 반영되어 있어 이 PR에 포함하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
